### PR TITLE
Fixed issue when adding new files

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,8 +144,8 @@ module.exports = function (loadPaths) {
 			}
 
 			if (!graph[file.path]) {
-				addToGraph(relativePath, function () {
-					return file.contents.toString('utf8')
+				addToGraph(file.path, function () {
+					return file.contents.toString('utf8');
 				});
 			}
 


### PR DESCRIPTION
Discovered a bug where if you are watching sass files and create a new one it would throw an error that relativePath does not exist on line #147. Based on my use case this change seemed to have fixed it for me and I think it will for others as well.
